### PR TITLE
Fix version string to list properly.

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1109,7 +1109,7 @@ std::string FormatSubVersion(const std::string& name, int nClientVersion, const 
     if (!comments.empty())
         ss << "(" << boost::algorithm::join(comments, "; ") << ")";
     ss << "/";
-    ss << "Paycoin:" << FormatVersion(PPCOIN_VERSION);
+    ss << "Peercoin:" << FormatVersion(PPCOIN_VERSION);
     ss << "/";
     ss << "Paycoin:" << FormatVersion(PEERUNITY_VERSION);
     ss << "(" << CLIENT_BUILD << ")/";


### PR DESCRIPTION
This will change subver (in peerinfo) to list as:
/Satoshi:0.6.3/Peercoin:0.4.0/Paycoin:*.*.*.*(v*.*.*.*-~)/

instead of
/Satoshi:0.6.3/Paycoin:0.4.0/Paycoin:*.*.*.*(v*.*.*.*-~)/

As this is derived from the Peercoin/Peerunity client which is derived from the Satoshi client.