### PR TITLE
Remove checkpoint-warning:

### DIFF
--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -364,16 +364,6 @@ namespace Checkpoints
         return (nBestHeight >= pindexSync->nHeight + nCoinbaseMaturity ||
                 pindexSync->GetBlockTime() + nStakeMinAge < GetAdjustedTime());
     }
-
-    // Is the sync-checkpoint too old?
-    bool IsSyncCheckpointTooOld(unsigned int nSeconds)
-    {
-        LOCK(cs_hashSyncCheckpoint);
-        // sync-checkpoint should always be accepted block
-        assert(mapBlockIndex.count(hashSyncCheckpoint));
-        const CBlockIndex* pindexSync = mapBlockIndex[hashSyncCheckpoint];
-        return (pindexSync->GetBlockTime() + nSeconds < GetAdjustedTime());
-    }
 }
 
 // paycoin: sync-checkpoint master key

--- a/src/checkpoints.h
+++ b/src/checkpoints.h
@@ -46,7 +46,6 @@ namespace Checkpoints
     bool SetCheckpointPrivKey(std::string strPrivKey);
     bool SendSyncCheckpoint(uint256 hashCheckpoint);
     bool IsMatureSyncCheckpoint();
-    bool IsSyncCheckpointTooOld(unsigned int nSeconds);
 }
 
 // paycoin: synchronized checkpoint

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2766,14 +2766,6 @@ string GetWarnings(string strFor)
         strStatusBar = strMiscWarning;
     }
 
-    // paycoin: should not enter safe mode for longer invalid chain
-    // paycoin: if sync-checkpoint is too old do not enter safe mode
-    if (Checkpoints::IsSyncCheckpointTooOld(60 * 60 * 24 * 30) && !fTestNet)
-    {
-        nPriority = 100;
-        strStatusBar = "WARNING: Checkpoint is too old. Wait for block chain to download, or notify developers of the issue.";
-    }
-
     // paycoin: if detected invalid checkpoint enter safe mode
     if (Checkpoints::hashInvalidCheckpoint != 0)
     {


### PR DESCRIPTION
Centralized checkpoints are not being used and this code is
more or less dead anyway. This leaves behind the rest of the
broadcast checkpoint code while removing the warning from
the client side.